### PR TITLE
Add oslog usage on macOS

### DIFF
--- a/minilog.h
+++ b/minilog.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 /**
 	minilog v1.1.0
@@ -28,7 +28,7 @@ struct LogConfig {
 	bool forceFlush                  = true;           // call fflush() after every log() and logRaw()
 	bool writeIntro                  = true;
 	bool writeOutro                  = true;
-	bool coloredConsole              = true;         // apply colors to console output (Windows, escape sequences)
+	bool coloredConsole              = true;         // apply colors to console output (Windows, macOS, escape sequences)
 	bool htmlLog                     = false;        // output everything as HTML instead of plain text
 	bool threadNames                 = true;         // prefix log messages with thread names
 	const char* htmlPageTitle        = "Minilog";    // just the title of the resulting HTML page


### PR DESCRIPTION
Xcode 15 is coloring the console automatically if we use oslog.

<img width="731" alt="Снимок экрана 2023-09-22 в 10 08 53" src="https://github.com/corporateshark/minilog/assets/5437220/48c838ed-a64c-4c50-9070-9c0884c65368">
